### PR TITLE
Add libusb to OSX prereqs

### DIFF
--- a/samples-aux/README.txt
+++ b/samples-aux/README.txt
@@ -49,6 +49,7 @@ Requires:
 At the terminal command line:
 $ brew install homebrew/science/opencv
 $ brew install sfml
+$ brew install libusb
 
 Now you can run the pre-built binaries from the Astra SDK bin/ directory.
 

--- a/samples-aux/README.txt
+++ b/samples-aux/README.txt
@@ -47,7 +47,6 @@ Requires:
 * homebrew from http://brew.sh/
 
 At the terminal command line:
-$ brew install homebrew/science/opencv
 $ brew install sfml
 $ brew install libusb
 


### PR DESCRIPTION
Just a small addition to the docs. Not sure if this needs to get added to other platforms as well...I'll leave that to you all :wink: 

https://3dclub.orbbec3d.com/t/cant-run-samples-on-os-x/98/4?u=mattfelsen
